### PR TITLE
✨ Automatise la création d'une resource activeadmin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,26 @@
 PATH
   remote: .
   specs:
-    captive-admin (0.2.8)
-      captive-theme (= 0.2.8)
+    captive-admin (0.2.9)
+      captive-theme (= 0.2.9)
       rails (>= 7.0.0)
-    captive-api (0.2.8)
+    captive-api (0.2.9)
       cancancan (>= 3.5.0)
       oj (>= 3.15.0)
       rails (>= 7.0.0)
-    captive-authentication (0.2.8)
+    captive-authentication (0.2.9)
       devise (~> 4.9.2)
       devise-i18n (~> 1.11.0)
       email_validator (~> 2.2.4)
       httparty (~> 0.21.0)
       omniauth (~> 2.1.1)
       rails (>= 7.0.0)
-    captive-sdk (0.2.8)
-      captive-admin (= 0.2.8)
-      captive-api (= 0.2.8)
-      captive-authentication (= 0.2.8)
-      captive-theme (= 0.2.8)
-    captive-theme (0.2.8)
+    captive-sdk (0.2.9)
+      captive-admin (= 0.2.9)
+      captive-api (= 0.2.9)
+      captive-authentication (= 0.2.9)
+      captive-theme (= 0.2.9)
+    captive-theme (0.2.9)
 
 GEM
   remote: https://rubygems.org/

--- a/captive-admin/README.md
+++ b/captive-admin/README.md
@@ -29,6 +29,14 @@ gem 'captive-admin'
   @import "captive-admin/base";
   ```
 
+## Usage
+
+You can use the admin generator. [See the usage doc to read more information](./lib/generators/admin/USAGE) :
+
+```console
+bin/rails generate admin Thing
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/Captive-Studio/captive-sdk.

--- a/captive-admin/lib/generators/admin/USAGE
+++ b/captive-admin/lib/generators/admin/USAGE
@@ -1,0 +1,10 @@
+Description:
+    Créé une resource ActiveAdmin au standard
+
+Example:
+    bin/rails generate admin Thing
+
+    This will create:
+        app/admin/things.rb
+        app/views/admin/things/_form.html.arb
+        app/views/admin/things/_show.html.arb

--- a/captive-admin/lib/generators/admin/admin_generator.rb
+++ b/captive-admin/lib/generators/admin/admin_generator.rb
@@ -3,14 +3,14 @@ class AdminGenerator < Rails::Generators::NamedBase
   def create_resource_file
     say "Voir le Standard : https://captive.notion.site/ActiveAdmin-Personnaliser-l-index-e7869c1bd6064e94a623eb7950d1ca8c?pvs=4",
         :blue
-    cree_resource
-    cree_show
-    cree_form
+    create_resource
+    create_show
+    create_form
   end
 
   private
 
-  def cree_resource
+  def create_resource
     create_file "app/admin/#{plural_name}.rb", <<~RUBY
     # frozen_string_literal: true
 
@@ -33,7 +33,7 @@ class AdminGenerator < Rails::Generators::NamedBase
     RUBY
   end
 
-  def cree_show
+  def create_show
     create_file "app/views/admin/#{plural_name}/_show.html.arb", <<~RUBY
 # frozen_string_literal: true
 
@@ -45,7 +45,7 @@ end
     RUBY
   end
 
-  def cree_form
+  def create_form
     create_file "app/views/admin/#{plural_name}/_form.html.arb", <<~RUBY
 # frozen_string_literal: true
 

--- a/captive-admin/lib/generators/admin/admin_generator.rb
+++ b/captive-admin/lib/generators/admin/admin_generator.rb
@@ -83,17 +83,16 @@ end
   def associations
     @associations ||=
       columns.map do |c|
-        association =
-          class_name.constantize.reflect_on_all_associations.find do |a|
-            a.association_foreign_key == c
-          end&.name
+        class_name.constantize.reflect_on_all_associations.find do |a|
+          a.association_foreign_key == c
+        end&.name
       end.compact
   end
 
   def includes
     return if associations.blank?
 
-    "\n  includes :#{associations.join(', ')}\n"
+    "\n  includes :#{associations.join(", ")}\n"
   end
 
   PERMIT_PARAMS_EXCLUDED = [

--- a/captive-admin/lib/generators/admin/admin_generator.rb
+++ b/captive-admin/lib/generators/admin/admin_generator.rb
@@ -1,0 +1,96 @@
+class AdminGenerator < Rails::Generators::NamedBase
+  desc "Créé une resource ActiveAdmin au standard"
+  def create_resource_file
+    say "Voir le Standard : https://captive.notion.site/ActiveAdmin-Personnaliser-l-index-e7869c1bd6064e94a623eb7950d1ca8c?pvs=4",
+        :blue
+    cree_resource
+    cree_show
+    cree_form
+  end
+
+  private
+
+  def cree_resource
+    create_file "app/admin/#{plural_name}.rb", <<~RUBY
+    # frozen_string_literal: true
+
+    ActiveAdmin.register #{class_name} do
+      config.sort_order = "created_at_desc"
+
+      permit_params #{permit_params.map { |p| ":#{p}" }.join(", ")}
+
+      index do
+        #{index_columns.map { |attr| "column :#{attr}" }.join("\n    ")}
+        actions dropdown: true
+      end
+
+      show do
+        render partial: "admin/#{plural_name}/show", locals: { resource: resource }
+      end
+
+      form partial: "admin/#{plural_name}/form"
+    end
+    RUBY
+  end
+
+  def cree_show
+    create_file "app/views/admin/#{plural_name}/_show.html.arb", <<~RUBY
+# frozen_string_literal: true
+
+panel "Détails #{plural_name}" do
+  attributes_table_for resource do
+    #{show_rows.map { |attr| "row :#{attr}" }.join("\n    ")}
+  end
+end
+    RUBY
+  end
+
+  def cree_form
+    create_file "app/views/admin/#{plural_name}/_form.html.arb", <<~RUBY
+# frozen_string_literal: true
+
+active_admin_form_for [:admin, resource] do |f|
+  f.semantic_errors
+  f.inputs do
+    #{permit_params.map { |p| "f.input :#{p}" }.join("\n    ")}
+  end
+  f.actions
+end
+        RUBY
+  end
+
+  def columns
+    @columns ||=
+      class_name.constantize
+        .columns
+        .map(&:name)
+  end
+
+  PERMIT_PARAMS_EXCLUDED = [
+    "id",
+    "created_at",
+    "updated_at",
+    "encrypted_password",
+    "reset_password_token",
+    "reset_password_sent_at",
+    "remember_created_at",
+  ].freeze
+  def permit_params
+    permit_params = columns.excluding(PERMIT_PARAMS_EXCLUDED)
+    if columns.include?("encrypted_password")
+      permit_params << "password"
+      permit_params << "password_confirmation"
+    end
+    permit_params
+  end
+
+  INDEX_EXCLUDED = PERMIT_PARAMS_EXCLUDED
+  def index_columns
+    columns.excluding(INDEX_EXCLUDED)
+  end
+
+  SHOW_EXCLUDED = ["encrypted_password"].freeze
+  def show_rows
+    columns.excluding(INDEX_EXCLUDED)
+  end
+end

--- a/captive-admin/lib/generators/admin/admin_generator.rb
+++ b/captive-admin/lib/generators/admin/admin_generator.rb
@@ -18,7 +18,7 @@ class AdminGenerator < Rails::Generators::NamedBase
       config.sort_order = "created_at_desc"
 
       permit_params #{permit_params.map { |p| ":#{p}" }.join(", ")}
-
+    #{includes}
       index do
         #{index_columns.map { |attr| "column :#{attr}" }.join("\n    ")}
         actions dropdown: true
@@ -78,6 +78,22 @@ end
 
         association.name.to_s
       end
+  end
+
+  def associations
+    @associations ||=
+      columns.map do |c|
+        association =
+          class_name.constantize.reflect_on_all_associations.find do |a|
+            a.association_foreign_key == c
+          end&.name
+      end.compact
+  end
+
+  def includes
+    return if associations.blank?
+
+    "\n  includes :#{associations.join(', ')}\n"
   end
 
   PERMIT_PARAMS_EXCLUDED = [


### PR DESCRIPTION
via la commande : `bin/rails generate admin Toto`

L'objectif est de créer une resource activeadmin au standard de Captive rapidement

La commande doit automatiser l'ensemble des actions des développeurs. Si une nouvelle action est requise, il faut l'ajouter au generator.

Ceci est un premier pas, les améliorations suivantes peuvent être apportés :
- automatisation des `includes` pour éviter N+1 query
- création automatique des tests Rspec pour l'index/show/create/update

---

Voici un exemple de ce que j'ai généré sur Hedwige pour le model AdminUser : 

```ruby
# app/admin/admin_users.rb
# frozen_string_literal: true

ActiveAdmin.register AdminUser do
  config.sort_order = "created_at_desc"

  permit_params :email, :provider, :uid, :password, :password_confirmation

  index do
    column :email
    column :provider
    column :uid
    actions dropdown: true
  end

  show do
    render partial: "admin/admin_users/show", locals: { resource: resource }
  end

  form partial: "admin/admin_users/form"
end
```

```ruby
# app/views/admin/_show.html.arb
# frozen_string_literal: true

active_admin_form_for [:admin, resource] do |f|
  f.semantic_errors
  f.inputs do
    f.input :email
    f.input :provider
    f.input :uid
    f.input :password
    f.input :password_confirmation
  end
  f.actions
end
```

```ruby
# app/views/admin/_show.html.arb
# frozen_string_literal: true

panel "Détails admin_users" do
  attributes_table_for resource do
    row :id
    row :email
    row :encrypted_password
    row :reset_password_token
    row :reset_password_sent_at
    row :remember_created_at
    row :created_at
    row :updated_at
    row :provider
    row :uid
  end
end
```