### PR TITLE
🐛 Corrige le chargement de captive-theme

### DIFF
--- a/captive-admin/lib/captive/admin.rb
+++ b/captive-admin/lib/captive/admin.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "captive/admin/engine"
+require "captive/theme"
 
 module Captive
   module Admin


### PR DESCRIPTION
Avant il fallait obligatoirement indiqué les deux gems dans le Gemfile :

```ruby
gem "captive-admin"
gem "captive-theme"
```

---

Avec ce changement, plus besoin de spécifier "captive-theme" dans le fichier

Si on ne require pas la gem avant l'initialisation de captive-admin, alors la gem captive-theme serait loader seulement au moment où elle est appelé dans notre app.

Voir ici pour plus de détail : https://guides.rubyonrails.org/engines.html#other-gem-dependencies

---

Il faudrait modifier le template rails de captive-admin pour ne plus ajouter captive-theme dans le Gemfile : https://github.com/Captive-Studio/rails-application-templates/blob/main/captive_admin.rb